### PR TITLE
Use official API signatures

### DIFF
--- a/includes/runtime/class-content-model-data-hydrator.php
+++ b/includes/runtime/class-content-model-data-hydrator.php
@@ -49,7 +49,9 @@ class Content_Model_Data_Hydrator {
 				continue;
 			}
 
-			foreach ( $content_model_block->get_bindings() as $attribute => $field ) {
+			foreach ( $content_model_block->get_bindings() as $attribute => $binding ) {
+				$field = $binding['args']['key'];
+
 				if ( 'post_content' === $field ) {
 					$content = get_the_content();
 				} else {
@@ -82,6 +84,8 @@ class Content_Model_Data_Hydrator {
 				$blocks[ $index ]['innerHTML']    = $inner_html;
 				$blocks[ $index ]['innerContent'] = array( $inner_html );
 			}
+
+			$blocks[ $index ]['attrs'] = apply_filters( 'hydrate_block_attributes', $blocks[ $index ]['attrs'] );
 		}
 
 		return $blocks;

--- a/includes/runtime/class-content-model.php
+++ b/includes/runtime/class-content-model.php
@@ -103,7 +103,7 @@ final class Content_Model {
 				continue;
 			}
 
-			$acc[] = $content_model_block;
+			$acc[ $content_model_block->get_block_variation_name() ] = $content_model_block;
 		}
 
 		return $acc;
@@ -115,9 +115,11 @@ final class Content_Model {
 	 * @return void
 	 */
 	private function register_meta_fields() {
-		foreach ( $this->blocks as $block ) {
-			foreach ( $block->get_bindings() as $attribute => $meta_field ) {
-				if ( 'post_content' === $meta_field ) {
+		foreach ( $this->blocks as $block_variation_name => $block ) {
+			foreach ( $block->get_bindings() as $attribute => $binding ) {
+				$field = $binding['args']['key'];
+
+				if ( 'post_content' === $field ) {
 					continue;
 				}
 
@@ -127,7 +129,7 @@ final class Content_Model {
 
 				register_post_meta(
 					$this->slug,
-					$meta_field,
+					$field,
 					array(
 						'show_in_rest' => true,
 						'single'       => true,
@@ -221,7 +223,7 @@ final class Content_Model {
 
 		$blocks = parse_blocks( wp_unslash( $post->post_content ) );
 
-		$data_extractor = new Content_Model_Data_Extractor( $blocks );
+		$data_extractor = new Content_Model_Data_Extractor( $blocks, $this->blocks );
 
 		wp_update_post(
 			array(
@@ -245,7 +247,22 @@ final class Content_Model {
 		}
 
 		$data_hydrator = new Content_Model_Data_Hydrator( $this->template );
-
+		add_filter( 'hydrate_block_attributes', array( $this, 'remove_bindings_from_attributes' ) );
 		$post->post_content = serialize_blocks( $data_hydrator->hydrate() );
+		remove_filter( 'hydrate_block_attributes', array( $this, 'remove_bindings_from_attributes' ) );
+	}
+
+	/**
+	 * We need to remove the bindings in data entry mode, otherwise it's not
+	 * possible to modify the bound attributes.
+	 *
+	 * @param array $attrs The block attributes.
+	 *
+	 * @return array The block attributes.
+	 */
+	public function remove_bindings_from_attributes( $attrs ) {
+		unset( $attrs['metadata']['bindings'] );
+
+		return $attrs;
 	}
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/create-content-model/issues/3.

We don't need to create a nested object in `metadata`. Let's use the official APIs to register the bound fields. We're also using the `metadata.name` attribute so that the variations show up with the correct name in the sidebar:

![image](https://github.com/user-attachments/assets/24704938-7b49-4718-a5da-82e1f5601218)
