### PR TITLE
Allow only one version of the plugin to be activated

### DIFF
--- a/create-content-model.php
+++ b/create-content-model.php
@@ -9,6 +9,17 @@
 
 declare( strict_types = 1 );
 
+if ( defined( 'CONTENT_MODEL_PLUGIN_FILE' ) ) {
+	wp_die(
+		esc_html__( 'Only one version of the Create Content Model (Main, Scaffolded) plugin can be active.' ),
+		esc_html__( 'Plugin Activation Error' ),
+		array(
+			'link_text' => esc_html__( 'Return to Plugins Page' ),
+			'link_url'  => esc_url( admin_url( 'plugins.php' ) ),
+		)
+	);
+}
+
 define( 'CONTENT_MODEL_PLUGIN_FILE', __FILE__ );
 define( 'CONTENT_MODEL_PLUGIN_PATH', plugin_dir_path( __FILE__ ) );
 define( 'CONTENT_MODEL_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
@@ -18,9 +29,11 @@ define( 'CONTENT_MODEL_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
  *
  * @param string $file The file to require.
  */
-function content_model_require_if_exists( string $file ) {
-	if ( file_exists( $file ) ) {
-		require_once $file;
+if ( ! function_exists( 'content_model_require_if_exists' ) ) {
+	function content_model_require_if_exists( string $file ) {
+		if ( file_exists( $file ) ) {
+			require_once $file;
+		}
 	}
 }
 


### PR DESCRIPTION
Will return an error page when the user tries to activate both plugins on the same site:


https://github.com/user-attachments/assets/aab5bd86-b3e1-4121-8127-85218b34a1fb

