### PR TITLE
Fix multiple selector attribute replacing

### DIFF
--- a/includes/runtime/0-load.php
+++ b/includes/runtime/0-load.php
@@ -12,6 +12,6 @@ require_once __DIR__ . '/class-content-model.php';
 require_once __DIR__ . '/class-content-model-block.php';
 require_once __DIR__ . '/class-content-model-data-extractor.php';
 require_once __DIR__ . '/class-content-model-data-hydrator.php';
-require_once __DIR__ . '/class-content-model-html-handler.php';
+require_once __DIR__ . '/class-content-model-html-manipulator.php';
 
 add_action( 'init', array( Content_Model_Manager::class, 'get_instance' ) );

--- a/includes/runtime/class-content-model-block.php
+++ b/includes/runtime/class-content-model-block.php
@@ -259,7 +259,7 @@ final class Content_Model_Block {
 
 		$parsed_block['innerBlocks'] = parse_blocks( $content );
 
-		$html_handler = new Content_Model_Html_Handler( $parsed_block['innerHTML'] );
+		$html_handler = new Content_Model_Html_Manipulator( $parsed_block['innerHTML'] );
 
 		$block_attribute['source']   = 'rich-text';
 		$block_attribute['selector'] = 'div';

--- a/includes/runtime/class-content-model-data-extractor.php
+++ b/includes/runtime/class-content-model-data-extractor.php
@@ -161,7 +161,7 @@ class Content_Model_Data_Extractor {
 			return null;
 		}
 
-		$html_handler = new Content_Model_Html_Handler( $block['innerHTML'] );
+		$html_handler = new Content_Model_Html_Manipulator( $block['innerHTML'] );
 
 		return $html_handler->extract_attribute( $allowed_attributes[ $attribute ] );
 	}

--- a/includes/runtime/class-content-model-data-hydrator.php
+++ b/includes/runtime/class-content-model-data-hydrator.php
@@ -67,7 +67,7 @@ class Content_Model_Data_Hydrator {
 				if ( 'core/group' === $block['blockName'] ) {
 					$blocks[ $index ]['innerBlocks'] = parse_blocks( $content );
 
-					$html_handler = new Content_Model_Html_Handler( $block['innerHTML'] );
+					$html_handler = new Content_Model_Html_Manipulator( $block['innerHTML'] );
 
 					$block_attribute['source']   = 'rich-text';
 					$block_attribute['selector'] = 'div';
@@ -87,7 +87,7 @@ class Content_Model_Data_Hydrator {
 					continue;
 				}
 
-				$html_handler = new Content_Model_Html_Handler( $block['innerHTML'] );
+				$html_handler = new Content_Model_Html_Manipulator( $block['innerHTML'] );
 
 				$blocks[ $index ]['innerHTML']    = $html_handler->replace_attribute( $block_attribute, $content );
 				$blocks[ $index ]['innerContent'] = array( $blocks[ $index ]['innerHTML'] );

--- a/includes/runtime/class-content-model-html-manipulator.php
+++ b/includes/runtime/class-content-model-html-manipulator.php
@@ -10,7 +10,7 @@ declare( strict_types = 1 );
 /**
  * Handles HTML associated with a block.
  */
-class Content_Model_Html_Handler {
+class Content_Model_Html_Manipulator {
 	/**
 	 * The DOM tree from the $markup.
 	 *
@@ -19,9 +19,9 @@ class Content_Model_Html_Handler {
 	private $dom;
 
 	/**
-	 * Creates an instance of the handler, with the HTML as the argument.
+	 * Creates an instance of the handler, with the HTML to be manipulated as the argument.
 	 *
-	 * @param string $markup The HTML to be analyzed.
+	 * @param string $markup The HTML to be manipulated.
 	 */
 	public function __construct( $markup ) {
 		$dom = new DOMDocument();


### PR DESCRIPTION
Fixes https://github.com/Automattic/create-content-model/issues/28.

The [`Heading` block targets content through `h1,h2,h3,h4,h5,h6`](https://github.com/WordPress/gutenberg/blob/6533c3265bb3db48b499ca2120f60b1b7966455b/packages/block-library/src/heading/block.json#L17). Our DOM manipulator wasn't handling that well. Now it is.