### PR TITLE
Restrict content model title length to prevent errors

### DIFF
--- a/includes/manager/class-content-model-loader.php
+++ b/includes/manager/class-content-model-loader.php
@@ -48,6 +48,7 @@ class Content_Model_Loader {
 		$this->register_post_type();
 		$this->maybe_enqueue_the_attribute_binder();
 		$this->maybe_enqueue_the_fields_ui();
+		$this->maybe_enqueue_content_model_length_restrictor();
 	}
 
 	/**
@@ -186,6 +187,36 @@ class Content_Model_Loader {
 				);
 
 				wp_enqueue_script( 'data-types/fields-ui' );
+			}
+		);
+	}
+
+	/**
+	 * Conditionally enqueues the content model length restrictor script for the block editor.
+	 *
+	 * Checks if the current post is of the correct type before enqueueing the script.
+	 *
+	 * @return void
+	 */
+	private function maybe_enqueue_content_model_length_restrictor() {
+		add_action(
+			'enqueue_block_editor_assets',
+			function () {
+				global $post;
+
+				if ( ! $post || Content_Model_Manager::POST_TYPE_NAME !== $post->post_type ) {
+					return;
+				}
+
+				$content_model_length_restrictor_js = include CONTENT_MODEL_PLUGIN_PATH . '/includes/manager/dist/content-model-title-length-restrictor.asset.php';
+
+				wp_enqueue_script(
+					'content-model/length-restrictor',
+					CONTENT_MODEL_PLUGIN_URL . '/includes/manager/dist/content-model-title-length-restrictor.js',
+					$content_model_length_restrictor_js['dependencies'],
+					$content_model_length_restrictor_js['version'],
+					true
+				);
 			}
 		);
 	}

--- a/includes/manager/content-model-title-length-restrictor.js
+++ b/includes/manager/content-model-title-length-restrictor.js
@@ -1,0 +1,33 @@
+import { __ } from '@wordpress/i18n';
+import { useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { store as noticesStore } from '@wordpress/notices';
+import { registerPlugin } from '@wordpress/plugins';
+
+const ContentModelLengthRestrictor = () => {
+	const { editPost } = useDispatch( editorStore );
+	const { createNotice } = useDispatch( noticesStore );
+
+	const title = useSelect( ( select ) =>
+		select( editorStore ).getEditedPostAttribute( 'title' )
+	);
+
+	useEffect( () => {
+		if ( title && title.length > 20 ) {
+			editPost( { title: title.substring( 0, 20 ) } );
+			createNotice(
+				'warning',
+				__( 'Title is limited to 20 characters.' ),
+				{
+					type: 'snackbar',
+					isDismissible: true,
+				}
+			);
+		}
+	}, [ title, editPost, createNotice ] );
+};
+
+registerPlugin( 'content-model-title-length-restrictor', {
+	render: ContentModelLengthRestrictor,
+} );


### PR DESCRIPTION
Fixes #29 

This gates it from the front end, which would be good enough for now.

https://github.com/user-attachments/assets/1f30bb70-b59c-4d6c-bce0-fc658b05503e

