### PR TITLE
Fields UI Cleanup - Better approach to post meta management by separating "Fields" from "Blocks"

### DIFF
--- a/includes/manager/class-content-model-loader.php
+++ b/includes/manager/class-content-model-loader.php
@@ -122,6 +122,22 @@ class Content_Model_Loader {
 			)
 		);
 
+		register_post_meta(
+			Content_Model_Manager::POST_TYPE_NAME,
+			'blocks',
+			array(
+				'type'              => 'string',
+				'single'            => true,
+				'sanitize_callback' => '',
+				'default'           => '[]',
+				'show_in_rest'      => array(
+					'schema ' => array(
+						'type' => 'string',
+					),
+				),
+			)
+		);
+
 		$cpt_fields = array(
 			'plural_label' => array(
 				'type'         => 'string',

--- a/includes/manager/src/components/attribute-binder-panel.js
+++ b/includes/manager/src/components/attribute-binder-panel.js
@@ -35,12 +35,12 @@ export const AttributeBinderPanel = ( { attributes, setAttributes, name } ) => {
 		'meta'
 	);
 
-	const fields = useMemo( () => {
-		return meta?.fields ? JSON.parse( meta.fields ) : [];
-	}, [ meta.fields ] );
+	const blocks = useMemo( () => {
+		return meta?.blocks ? JSON.parse( meta.blocks ) : [];
+	}, [ meta.blocks ] );
 
-	const boundField = fields.find(
-		( field ) => field.slug === attributes.metadata?.slug
+	const boundField = blocks.find(
+		( block ) => block.slug === attributes.metadata?.slug
 	);
 
 	const removeBindings = useCallback( () => {
@@ -54,25 +54,25 @@ export const AttributeBinderPanel = ( { attributes, setAttributes, name } ) => {
 		delete newAttributes.metadata[ BLOCK_VARIATION_NAME_ATTR ];
 		delete newAttributes.metadata.slug;
 
-		const newFields = fields.filter(
-			( field ) => field.slug !== attributes.metadata.slug
+		const newBlocks = blocks.filter(
+			( block ) => block.slug !== attributes.metadata.slug
 		);
 
 		setMeta( {
-			fields: JSON.stringify( newFields ),
+			blocks: JSON.stringify( newBlocks ),
 		} );
 
 		setAttributes( newAttributes );
-	}, [ attributes.metadata, setAttributes, fields, setMeta ] );
+	}, [ attributes.metadata, setAttributes, blocks, setMeta ] );
 
 	const setBinding = useCallback(
-		( field ) => {
+		( block ) => {
 			const newBindings = supportedAttributes.reduce(
 				( acc, attribute ) => {
 					acc[ attribute ] =
-						'post_content' === field.slug
-							? field.slug
-							: `${ field.slug }__${ attribute }`;
+						'post_content' === block.slug
+							? block.slug
+							: `${ block.slug }__${ attribute }`;
 
 					return acc;
 				},
@@ -82,8 +82,8 @@ export const AttributeBinderPanel = ( { attributes, setAttributes, name } ) => {
 			const newAttributes = {
 				metadata: {
 					...( attributes.metadata ?? {} ),
-					[ BLOCK_VARIATION_NAME_ATTR ]: field.label,
-					slug: field.slug,
+					[ BLOCK_VARIATION_NAME_ATTR ]: block.label,
+					slug: block.slug,
 					[ BINDINGS_KEY ]: newBindings,
 				},
 			};

--- a/includes/manager/src/components/attribute-binder-panel.js
+++ b/includes/manager/src/components/attribute-binder-panel.js
@@ -36,7 +36,6 @@ export const AttributeBinderPanel = ( { attributes, setAttributes, name } ) => {
 	);
 
 	const fields = useMemo( () => {
-		// Saving the fields as serialized JSON because I was tired of fighting the REST API.
 		return meta?.fields ? JSON.parse( meta.fields ) : [];
 	}, [ meta.fields ] );
 

--- a/includes/manager/src/components/edit-block.js
+++ b/includes/manager/src/components/edit-block.js
@@ -13,7 +13,14 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { blockDefault } from '@wordpress/icons';
+import {
+	blockDefault,
+	paragraph,
+	image,
+	heading,
+	group,
+	button,
+} from '@wordpress/icons';
 
 import { SUPPORTED_BLOCK_ATTRIBUTES } from '../constants';
 
@@ -42,7 +49,10 @@ const EditBlockForm = ( {
 							marginBottom: '1rem',
 						} }
 					>
-						<Button icon={ blockDefault } title={ formData.type }>
+						<Button
+							icon={ blockIcon( formData.type ) }
+							title={ formData.type }
+						>
 							{ __( 'Block Binding' ) }
 						</Button>
 					</ButtonGroup>
@@ -102,6 +112,23 @@ const BlockAttributes = ( { slug, type } ) => {
 			) ) }
 		</ItemGroup>
 	);
+};
+
+const blockIcon = ( type ) => {
+	switch ( type ) {
+		case 'core/paragraph':
+			return paragraph;
+		case 'core/image':
+			return image;
+		case 'core/heading':
+			return heading;
+		case 'core/group':
+			return group;
+		case 'core/button':
+			return button;
+		default:
+			return blockDefault;
+	}
 };
 
 export default EditBlockForm;

--- a/includes/manager/src/components/edit-block.js
+++ b/includes/manager/src/components/edit-block.js
@@ -1,0 +1,107 @@
+import {
+	Button,
+	ButtonGroup,
+	TextControl,
+	__experimentalGrid as Grid,
+	CardBody,
+	Card,
+	__experimentalItemGroup as ItemGroup,
+	__experimentalItem as Item,
+	Flex,
+	FlexBlock,
+	FlexItem,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useState, useEffect } from '@wordpress/element';
+import { blockDefault } from '@wordpress/icons';
+
+import { SUPPORTED_BLOCK_ATTRIBUTES } from '../constants';
+
+const EditBlockForm = ( {
+	block = {
+		label: '',
+		slug: '',
+		description: '',
+		type: 'text',
+		visible: false,
+	},
+	onChange = () => {},
+} ) => {
+	const [ formData, setFormData ] = useState( block );
+
+	useEffect( () => {
+		onChange( formData );
+	}, [ formData ] );
+
+	return (
+		<>
+			<Card>
+				<CardBody>
+					<ButtonGroup
+						style={ {
+							marginBottom: '1rem',
+						} }
+					>
+						<Button icon={ blockDefault } title={ formData.type }>
+							{ __( 'Block Binding' ) }
+						</Button>
+					</ButtonGroup>
+
+					<Grid columns={ 3 }>
+						<TextControl
+							label={ __( 'Name' ) }
+							value={ formData.label }
+							disabled={ true }
+						/>
+						<TextControl
+							label={ __( 'Key' ) }
+							value={ formData.slug }
+							disabled={ true }
+						/>
+						<TextControl
+							label={ __( 'Description (optional)' ) }
+							value={ formData.description }
+							onChange={ ( value ) =>
+								setFormData( {
+									...formData,
+									description: value,
+								} )
+							}
+						/>
+					</Grid>
+
+					<BlockAttributes
+						slug={ formData.slug }
+						type={ formData.type }
+					/>
+				</CardBody>
+			</Card>
+		</>
+	);
+};
+
+const BlockAttributes = ( { slug, type } ) => {
+	const supportedAttributes = SUPPORTED_BLOCK_ATTRIBUTES[ type ];
+	return (
+		<ItemGroup isBordered isSeparated>
+			{ supportedAttributes.map( ( attribute ) => (
+				<Item key={ attribute }>
+					<Flex>
+						<FlexBlock>{ attribute }</FlexBlock>
+						<FlexItem>
+							<span>
+								{ 'post_content' === slug ? (
+									<code>{ slug }</code>
+								) : (
+									<code>{ `${ slug }__${ attribute }` }</code>
+								) }
+							</span>
+						</FlexItem>
+					</Flex>
+				</Item>
+			) ) }
+		</ItemGroup>
+	);
+};
+
+export default EditBlockForm;

--- a/includes/manager/src/components/edit-field.js
+++ b/includes/manager/src/components/edit-field.js
@@ -14,15 +14,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import {
-	trash,
-	chevronUp,
-	chevronDown,
-	blockDefault,
-	post,
-} from '@wordpress/icons';
-
-import { SUPPORTED_BLOCK_ATTRIBUTES } from '../constants';
+import { trash, chevronUp, chevronDown, post } from '@wordpress/icons';
 
 const EditFieldForm = ( {
 	field = {
@@ -41,8 +33,6 @@ const EditFieldForm = ( {
 } ) => {
 	const [ formData, setFormData ] = useState( field );
 
-	const isBlock = formData.type.startsWith( 'core/' );
-
 	useEffect( () => {
 		onChange( formData );
 	}, [ formData ] );
@@ -56,18 +46,10 @@ const EditFieldForm = ( {
 							marginBottom: '1rem',
 						} }
 					>
-						{ isBlock ? (
-							<Button
-								icon={ blockDefault }
-								title={ formData.type }
-							>
-								{ __( 'Block Binding' ) }
-							</Button>
-						) : (
-							<Button icon={ post } title={ formData.type }>
-								{ __( 'Custom Field' ) }
-							</Button>
-						) }
+						<Button icon={ post } title={ formData.type }>
+							{ __( 'Custom Field' ) }
+						</Button>
+
 						{ index > 0 && (
 							<Button
 								icon={ chevronUp }
@@ -86,27 +68,26 @@ const EditFieldForm = ( {
 								} }
 							/>
 						) }
-						{ ! isBlock ?? (
-							<Button
-								icon={ trash }
-								title={ __( 'Delete Field' ) }
-								onClick={ () => {
-									// eslint-disable-next-line no-alert
-									const userWantsToDelete = confirm(
-										__(
-											'Are you sure you want to delete this field?'
-										)
-									);
 
-									if ( userWantsToDelete ) {
-										onDelete( formData );
-									}
-								} }
-							/>
-						) }
+						<Button
+							icon={ trash }
+							title={ __( 'Delete Field' ) }
+							onClick={ () => {
+								// eslint-disable-next-line no-alert
+								const userWantsToDelete = confirm(
+									__(
+										'Are you sure you want to delete this field?'
+									)
+								);
+
+								if ( userWantsToDelete ) {
+									onDelete( formData );
+								}
+							} }
+						/>
 					</ButtonGroup>
 
-					<Grid columns={ isBlock ? 3 : 4 }>
+					<Grid columns={ 4 }>
 						<TextControl
 							label={ __( 'Name' ) }
 							value={ formData.label }
@@ -134,75 +115,40 @@ const EditFieldForm = ( {
 							}
 						/>
 
-						{ ! isBlock && (
-							<SelectControl
-								label={ __( 'Field Type' ) }
-								value={ formData.type }
-								disabled={
-									formData.type.indexOf( 'core/' ) === 0
-								}
-								options={ [
-									{ label: __( 'Text' ), value: 'text' },
-									{
-										label: __( 'Textarea' ),
-										value: 'textarea',
-									},
-									{ label: __( 'URL' ), value: 'url' },
-									{ label: __( 'Image' ), value: 'image' },
-									{ label: __( 'Number' ), value: 'number' },
-								] }
-								onChange={ ( value ) =>
-									setFormData( { ...formData, type: value } )
-								}
-							/>
-						) }
-					</Grid>
-					{ isBlock ? (
-						<BlockAttributes
-							slug={ formData.slug }
-							type={ formData.type }
+						<SelectControl
+							label={ __( 'Field Type' ) }
+							value={ formData.type }
+							disabled={ formData.type.indexOf( 'core/' ) === 0 }
+							options={ [
+								{ label: __( 'Text' ), value: 'text' },
+								{
+									label: __( 'Textarea' ),
+									value: 'textarea',
+								},
+								{ label: __( 'URL' ), value: 'url' },
+								{ label: __( 'Image' ), value: 'image' },
+								{ label: __( 'Number' ), value: 'number' },
+							] }
+							onChange={ ( value ) =>
+								setFormData( { ...formData, type: value } )
+							}
 						/>
-					) : (
-						<ItemGroup isBordered isSeparated>
-							<Item>
-								<Flex>
-									<FlexBlock>{ formData.type }</FlexBlock>
-									<FlexItem>
-										<span>
-											<code>{ formData.slug }</code>
-										</span>
-									</FlexItem>
-								</Flex>
-							</Item>
-						</ItemGroup>
-					) }
+					</Grid>
+					<ItemGroup isBordered isSeparated>
+						<Item>
+							<Flex>
+								<FlexBlock>{ formData.type }</FlexBlock>
+								<FlexItem>
+									<span>
+										<code>{ formData.slug }</code>
+									</span>
+								</FlexItem>
+							</Flex>
+						</Item>
+					</ItemGroup>
 				</CardBody>
 			</Card>
 		</>
-	);
-};
-
-const BlockAttributes = ( { slug, type } ) => {
-	const supportedAttributes = SUPPORTED_BLOCK_ATTRIBUTES[ type ];
-	return (
-		<ItemGroup isBordered isSeparated>
-			{ supportedAttributes.map( ( attribute ) => (
-				<Item key={ attribute }>
-					<Flex>
-						<FlexBlock>{ attribute }</FlexBlock>
-						<FlexItem>
-							<span>
-								{ 'post_content' === slug ? (
-									<code>{ slug }</code>
-								) : (
-									<code>{ `${ slug }__${ attribute }` }</code>
-								) }
-							</span>
-						</FlexItem>
-					</Flex>
-				</Item>
-			) ) }
-		</ItemGroup>
 	);
 };
 

--- a/includes/manager/src/components/edit-field.js
+++ b/includes/manager/src/components/edit-field.js
@@ -41,6 +41,8 @@ const EditFieldForm = ( {
 } ) => {
 	const [ formData, setFormData ] = useState( field );
 
+	const isBlock = formData.type.startsWith( 'core/' );
+
 	useEffect( () => {
 		onChange( formData );
 	}, [ formData ] );
@@ -54,16 +56,16 @@ const EditFieldForm = ( {
 							marginBottom: '1rem',
 						} }
 					>
-						{ formData.type.indexOf( 'core/' ) === -1 ? (
-							<Button icon={ post } title={ formData.type }>
-								{ __( 'Custom Field' ) }
-							</Button>
-						) : (
+						{ isBlock ? (
 							<Button
 								icon={ blockDefault }
 								title={ formData.type }
 							>
 								{ __( 'Block Binding' ) }
+							</Button>
+						) : (
+							<Button icon={ post } title={ formData.type }>
+								{ __( 'Custom Field' ) }
 							</Button>
 						) }
 						{ index > 0 && (
@@ -84,7 +86,7 @@ const EditFieldForm = ( {
 								} }
 							/>
 						) }
-						{ formData.type.indexOf( 'core/' ) === -1 ?? (
+						{ ! isBlock ?? (
 							<Button
 								icon={ trash }
 								title={ __( 'Delete Field' ) }
@@ -104,11 +106,7 @@ const EditFieldForm = ( {
 						) }
 					</ButtonGroup>
 
-					<Grid
-						columns={
-							formData.type.indexOf( 'core/' ) === -1 ? 4 : 3
-						}
-					>
+					<Grid columns={ isBlock ? 3 : 4 }>
 						<TextControl
 							label={ __( 'Name' ) }
 							value={ formData.label }
@@ -136,7 +134,7 @@ const EditFieldForm = ( {
 							}
 						/>
 
-						{ formData.type.indexOf( 'core/' ) === -1 && (
+						{ ! isBlock && (
 							<SelectControl
 								label={ __( 'Field Type' ) }
 								value={ formData.type }
@@ -159,7 +157,7 @@ const EditFieldForm = ( {
 							/>
 						) }
 					</Grid>
-					{ formData.type.indexOf( 'core/' ) === 0 ? (
+					{ isBlock ? (
 						<BlockAttributes
 							slug={ formData.slug }
 							type={ formData.type }

--- a/includes/manager/src/components/edit-field.js
+++ b/includes/manager/src/components/edit-field.js
@@ -3,7 +3,6 @@ import {
 	ButtonGroup,
 	TextControl,
 	SelectControl,
-	ToggleControl,
 	__experimentalGrid as Grid,
 	CardBody,
 	Card,
@@ -105,10 +104,15 @@ const EditFieldForm = ( {
 						) }
 					</ButtonGroup>
 
-					<Grid columns={ 3 }>
+					<Grid
+						columns={
+							formData.type.indexOf( 'core/' ) === -1 ? 4 : 3
+						}
+					>
 						<TextControl
 							label={ __( 'Name' ) }
 							value={ formData.label }
+							disabled={ formData.type.indexOf( 'core/' ) === 0 }
 							onChange={ ( value ) =>
 								setFormData( { ...formData, label: value } )
 							}
@@ -116,6 +120,7 @@ const EditFieldForm = ( {
 						<TextControl
 							label={ __( 'Key' ) }
 							value={ formData.slug }
+							disabled={ formData.type.indexOf( 'core/' ) === 0 }
 							onChange={ ( value ) =>
 								setFormData( { ...formData, slug: value } )
 							}
@@ -130,11 +135,10 @@ const EditFieldForm = ( {
 								} )
 							}
 						/>
-					</Grid>
-					{ formData.type.indexOf( 'core/' ) === -1 && (
-						<Grid columns={ 2 } alignment="bottom">
+
+						{ formData.type.indexOf( 'core/' ) === -1 && (
 							<SelectControl
-								label={ __( 'Type' ) }
+								label={ __( 'Field Type' ) }
 								value={ formData.type }
 								disabled={
 									formData.type.indexOf( 'core/' ) === 0
@@ -153,20 +157,8 @@ const EditFieldForm = ( {
 									setFormData( { ...formData, type: value } )
 								}
 							/>
-							<ToggleControl
-								label={ __(
-									'Show Field in Custom Fields Form'
-								) }
-								checked={ formData.visible ?? false }
-								onChange={ ( value ) =>
-									setFormData( {
-										...formData,
-										visible: value,
-									} )
-								}
-							/>
-						</Grid>
-					) }
+						) }
+					</Grid>
 					{ formData.type.indexOf( 'core/' ) === 0 ? (
 						<BlockAttributes
 							slug={ formData.slug }

--- a/includes/manager/src/components/fields-ui.js
+++ b/includes/manager/src/components/fields-ui.js
@@ -14,7 +14,7 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useEntityProp } from '@wordpress/core-data';
 import { useState } from '@wordpress/element';
-import { seen, unseen, blockDefault } from '@wordpress/icons';
+import { seen, blockDefault } from '@wordpress/icons';
 
 import EditFieldForm from './edit-field';
 import { POST_TYPE_NAME } from '../constants';
@@ -51,23 +51,15 @@ export const FieldsUI = function () {
 										<code>{ field.slug }</code>
 									</FlexItem>
 
-									{ field.visible && (
+									{ field.type.indexOf( 'core' ) > -1 ? (
+										<FlexItem>
+											<Icon icon={ blockDefault } />
+										</FlexItem>
+									) : (
 										<FlexItem>
 											<Icon icon={ seen } />
 										</FlexItem>
 									) }
-									{ ! field.visible &&
-										field.type.indexOf( 'core' ) > -1 && (
-											<FlexItem>
-												<Icon icon={ blockDefault } />
-											</FlexItem>
-										) }
-									{ ! field.visible &&
-										field.type.indexOf( 'core' ) < 0 && (
-											<FlexItem>
-												<Icon icon={ unseen } />
-											</FlexItem>
-										) }
 								</Flex>
 							</Item>
 						) ) }
@@ -79,7 +71,7 @@ export const FieldsUI = function () {
 						variant="secondary"
 						onClick={ () => setFieldsOpen( true ) }
 					>
-						{ __( 'Manage Fields' ) }
+						{ __( 'Manage Post Meta' ) }
 					</Button>
 				</PanelRow>
 

--- a/includes/manager/src/components/fields-ui.js
+++ b/includes/manager/src/components/fields-ui.js
@@ -36,42 +36,44 @@ export const FieldsUI = function () {
 				title={ __( 'Post Meta' ) }
 				className="create-content-model-field-settings"
 			>
-				{ blocks.length > 0 && (
-					<ItemGroup isBordered isSeparated>
-						{ blocks.map( ( block ) => (
-							<Item key={ block.uuid }>
-								<Flex>
-									<FlexBlock>{ block.label }</FlexBlock>
-									<FlexItem>
-										<code>{ block.slug }</code>
-									</FlexItem>
+				<ItemGroup isBordered isSeparated>
+					{ blocks.length > 0 && (
+						<>
+							{ blocks.map( ( block ) => (
+								<Item key={ block.uuid }>
+									<Flex>
+										<FlexBlock>{ block.label }</FlexBlock>
+										<FlexItem>
+											<code>{ block.slug }</code>
+										</FlexItem>
 
-									<FlexItem>
-										<Icon icon={ blockDefault } />
-									</FlexItem>
-								</Flex>
-							</Item>
-						) ) }
-					</ItemGroup>
-				) }
-				{ fields.length > 0 && (
-					<ItemGroup isBordered isSeparated>
-						{ fields.map( ( field ) => (
-							<Item key={ field.uuid }>
-								<Flex>
-									<FlexBlock>{ field.label }</FlexBlock>
-									<FlexItem>
-										<code>{ field.slug }</code>
-									</FlexItem>
+										<FlexItem>
+											<Icon icon={ blockDefault } />
+										</FlexItem>
+									</Flex>
+								</Item>
+							) ) }
+						</>
+					) }
+					{ fields.length > 0 && (
+						<>
+							{ fields.map( ( field ) => (
+								<Item key={ field.uuid }>
+									<Flex>
+										<FlexBlock>{ field.label }</FlexBlock>
+										<FlexItem>
+											<code>{ field.slug }</code>
+										</FlexItem>
 
-									<FlexItem>
-										<Icon icon={ seen } />
-									</FlexItem>
-								</Flex>
-							</Item>
-						) ) }
-					</ItemGroup>
-				) }
+										<FlexItem>
+											<Icon icon={ seen } />
+										</FlexItem>
+									</Flex>
+								</Item>
+							) ) }
+						</>
+					) }
+				</ItemGroup>
 
 				<PanelRow>
 					<Button

--- a/includes/manager/src/components/fields-ui.js
+++ b/includes/manager/src/components/fields-ui.js
@@ -2,6 +2,7 @@ import { PluginDocumentSettingPanel } from '@wordpress/editor';
 import {
 	Button,
 	PanelRow,
+	TabPanel,
 	Modal,
 	__experimentalVStack as VStack,
 	__experimentalItemGroup as ItemGroup,
@@ -24,15 +25,7 @@ export const FieldsUI = function () {
 
 	const [ meta ] = useEntityProp( 'postType', POST_TYPE_NAME, 'meta' );
 
-	// Saving the fields as serialized JSON because I was tired of fighting the REST API.
 	const fields = meta?.fields ? JSON.parse( meta.fields ) : [];
-
-	// Add UUID to fields
-	fields.forEach( ( field ) => {
-		if ( ! field.uuid ) {
-			field.uuid = crypto.randomUUID();
-		}
-	} );
 
 	return (
 		<>
@@ -96,7 +89,6 @@ const FieldsList = () => {
 		'meta'
 	);
 
-	// Saving the fields as serialized JSON because I was tired of fighting the REST API.
 	const fields = meta?.fields ? JSON.parse( meta.fields ) : [];
 
 	// Save the fields back to the meta.

--- a/includes/manager/src/components/fields-ui.js
+++ b/includes/manager/src/components/fields-ui.js
@@ -74,7 +74,22 @@ export const FieldsUI = function () {
 						size="large"
 						onRequestClose={ () => setFieldsOpen( false ) }
 					>
-						<FieldsList />
+						<TabPanel
+							tabs={ [
+								{
+									name: 'fields',
+									title: __( 'Fields' ),
+									content: <FieldsList tab="fields" />,
+								},
+								{
+									name: 'blocks',
+									title: __( 'Blocks' ),
+									content: <FieldsList tab="blocks" />,
+								},
+							] }
+						>
+							{ ( tab ) => <>{ tab.content }</> }
+						</TabPanel>
 					</Modal>
 				) }
 			</PluginDocumentSettingPanel>
@@ -82,7 +97,7 @@ export const FieldsUI = function () {
 	);
 };
 
-const FieldsList = () => {
+const FieldsList = ( { tab } ) => {
 	const [ meta, setMeta ] = useEntityProp(
 		'postType',
 		POST_TYPE_NAME,
@@ -111,55 +126,64 @@ const FieldsList = () => {
 	return (
 		<>
 			<VStack spacing={ 2 }>
-				{ fields.map( ( field ) => (
-					<EditFieldForm
-						key={ field.uuid }
-						field={ field }
-						onDelete={ deleteField }
-						onChange={ editField }
-						total={ fields.length }
-						index={ fields.findIndex(
-							( f ) => f.uuid === field.uuid
-						) }
-						onMoveUp={ ( movedField ) => {
-							const index = fields.findIndex(
-								( f ) => f.uuid === movedField.uuid
-							);
-							const newFields = [ ...fields ];
-							newFields.splice( index, 1 );
-							newFields.splice( index - 1, 0, movedField );
-							setFields( newFields );
-						} }
-						onMoveDown={ ( movedField ) => {
-							const index = fields.findIndex(
-								( f ) => f.uuid === movedField.uuid
-							);
-							const newFields = [ ...fields ];
-							newFields.splice( index, 1 );
-							newFields.splice( index + 1, 0, movedField );
-							setFields( newFields );
-						} }
-					/>
-				) ) }
+				{ fields
+					.filter( ( field ) => {
+						if ( tab === 'fields' ) {
+							return ! field.type.startsWith( 'core/' );
+						}
 
-				<Button
-					variant="secondary"
-					onClick={ () =>
-						setFields( [
-							...fields,
-							{
-								uuid: crypto.randomUUID(),
-								label: '',
-								slug: '',
-								description: '',
-								type: 'text',
-								visible: true,
-							},
-						] )
-					}
-				>
-					{ __( 'Add Field' ) }
-				</Button>
+						return field.type.startsWith( 'core/' );
+					} )
+					.map( ( field ) => (
+						<EditFieldForm
+							key={ field.uuid }
+							field={ field }
+							onDelete={ deleteField }
+							onChange={ editField }
+							total={ fields.length }
+							index={ fields.findIndex(
+								( f ) => f.uuid === field.uuid
+							) }
+							onMoveUp={ ( movedField ) => {
+								const index = fields.findIndex(
+									( f ) => f.uuid === movedField.uuid
+								);
+								const newFields = [ ...fields ];
+								newFields.splice( index, 1 );
+								newFields.splice( index - 1, 0, movedField );
+								setFields( newFields );
+							} }
+							onMoveDown={ ( movedField ) => {
+								const index = fields.findIndex(
+									( f ) => f.uuid === movedField.uuid
+								);
+								const newFields = [ ...fields ];
+								newFields.splice( index, 1 );
+								newFields.splice( index + 1, 0, movedField );
+								setFields( newFields );
+							} }
+						/>
+					) ) }
+				{ tab === 'fields' ?? (
+					<Button
+						variant="secondary"
+						onClick={ () =>
+							setFields( [
+								...fields,
+								{
+									uuid: crypto.randomUUID(),
+									label: '',
+									slug: '',
+									description: '',
+									type: 'text',
+									visible: true,
+								},
+							] )
+						}
+					>
+						{ __( 'Add Field' ) }
+					</Button>
+				) }
 			</VStack>
 		</>
 	);

--- a/includes/manager/src/components/fields-ui.js
+++ b/includes/manager/src/components/fields-ui.js
@@ -15,7 +15,15 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useEntityProp } from '@wordpress/core-data';
 import { useState } from '@wordpress/element';
-import { seen, blockDefault } from '@wordpress/icons';
+import {
+	post,
+	blockDefault,
+	paragraph,
+	heading,
+	button,
+	group,
+	image,
+} from '@wordpress/icons';
 
 import EditFieldForm from './edit-field';
 import EditBlockForm from './edit-block';
@@ -42,13 +50,14 @@ export const FieldsUI = function () {
 							{ blocks.map( ( block ) => (
 								<Item key={ block.uuid }>
 									<Flex>
+										<FlexItem>
+											<Icon
+												icon={ blockIcon( block.type ) }
+											/>
+										</FlexItem>
 										<FlexBlock>{ block.label }</FlexBlock>
 										<FlexItem>
 											<code>{ block.slug }</code>
-										</FlexItem>
-
-										<FlexItem>
-											<Icon icon={ blockDefault } />
 										</FlexItem>
 									</Flex>
 								</Item>
@@ -60,13 +69,12 @@ export const FieldsUI = function () {
 							{ fields.map( ( field ) => (
 								<Item key={ field.uuid }>
 									<Flex>
+										<FlexItem>
+											<Icon icon={ post } />
+										</FlexItem>
 										<FlexBlock>{ field.label }</FlexBlock>
 										<FlexItem>
 											<code>{ field.slug }</code>
-										</FlexItem>
-
-										<FlexItem>
-											<Icon icon={ seen } />
 										</FlexItem>
 									</Flex>
 								</Item>
@@ -212,4 +220,20 @@ const BlocksList = () => {
 			</VStack>
 		</>
 	);
+};
+const blockIcon = ( type ) => {
+	switch ( type ) {
+		case 'core/paragraph':
+			return paragraph;
+		case 'core/image':
+			return image;
+		case 'core/heading':
+			return heading;
+		case 'core/group':
+			return group;
+		case 'core/button':
+			return button;
+		default:
+			return blockDefault;
+	}
 };

--- a/includes/manager/src/components/manage-bindings.js
+++ b/includes/manager/src/components/manage-bindings.js
@@ -24,26 +24,26 @@ const ManageBindings = ( {
 		'meta'
 	);
 
-	const fields = meta?.fields ? JSON.parse( meta.fields ) : [];
+	const blocks = meta?.blocks ? JSON.parse( meta.blocks ) : [];
 
 	const saveForm = ( e ) => {
 		e.preventDefault();
-		let newFields = fields;
+		let newBlocks = blocks;
 
-		if ( fields.find( ( field ) => field.uuid === formData.uuid ) ) {
-			// If the slug is the same and it exists, update the field.
-			newFields = newFields.map( ( field ) => {
-				if ( field.uuid === formData.uuid ) {
-					field = formData;
+		if ( blocks.find( ( block ) => block.uuid === formData.uuid ) ) {
+			// If the slug is the same and it exists, update the block.
+			newBlocks = newBlocks.map( ( block ) => {
+				if ( block.uuid === formData.uuid ) {
+					block = formData;
 				}
-				return field;
+				return block;
 			} );
 			setMeta( {
-				fields: JSON.stringify( newFields ),
+				blocks: JSON.stringify( newBlocks ),
 			} );
 		} else {
 			setMeta( {
-				fields: JSON.stringify( [ ...newFields, formData ] ),
+				blocks: JSON.stringify( [ ...newBlocks, formData ] ),
 			} );
 		}
 		onSave( formData );

--- a/includes/manager/src/components/manage-bindings.js
+++ b/includes/manager/src/components/manage-bindings.js
@@ -10,7 +10,7 @@ const ManageBindings = ( {
 		slug: '',
 		description: '',
 		type: 'text',
-		visible: true,
+		visible: false,
 		uuid: crypto.randomUUID(),
 	},
 	onSave = () => {},


### PR DESCRIPTION
Here's a suggested approach that does a few things:

- Separates how we store "fields" from "blocks" by registering a new postmeta field on the content_model post type.
- Separates a ton of components in the fields UI instead of using inline conditionals everywhere
- Adds a tabbed view to the fields UI modal -  "fields" is an editable/sortable list and "blocks" just shows all the meta keys for all of your bindings for a overview of your data model

**This is a breaking change**

## Screenshots

<img width="356" alt="Screenshot 2024-08-30 at 8 29 58 AM" src="https://github.com/user-attachments/assets/b217d284-2857-4747-95f4-0509bbab7a74">
<img width="913" alt="Screenshot 2024-08-30 at 8 30 31 AM" src="https://github.com/user-attachments/assets/e721db3b-0c7e-4f4d-b6c8-38756359bd57">
<img width="903" alt="Screenshot 2024-08-30 at 8 30 43 AM" src="https://github.com/user-attachments/assets/5f0f04a6-75be-43b4-96cf-3b472031dce0">



Replaces #76