### PR TITLE
Removes defaults for post meta fields that aren't bound blocks

### DIFF
--- a/includes/runtime/class-content-model.php
+++ b/includes/runtime/class-content-model.php
@@ -208,7 +208,6 @@ final class Content_Model {
 						'show_in_rest' => true,
 						'single'       => true,
 						'type'         => 'string', // todo: support other types.
-						'default'      => $field['default'] ?? $field['slug'],
 					)
 				);
 			}


### PR DESCRIPTION
There's no need to add defaults for sidebar fields.