### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: "tagged-release"
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  tagged-release:
+    name: "Tagged Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@master
+      - name: Fetch Tags
+        run: git fetch --tags --force
+      - id: tag-message
+        run: git tag -l --sort=-taggerdate --format='%(contents)' $(git describe --tags $(git branch --show-current))
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm install
+      - run: "find . -type f -exec sed -i 's/0.0.0-placeholder/${{ github.ref_name }}/g' {} +"
+      - run: npm run plugin-zip
+      - uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.tag-message.outputs.stdout }}
+          files: create-content-model.zip
+          make_latest: true

--- a/create-content-model.php
+++ b/create-content-model.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Create Content Model
  * Description: Create content models in WP Admin.
- * Version: 1.0
+ * Version: 0.0.0-placeholder
  *
  * @package content-model
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "create-content-model",
-    "version": "1.0.0",
+    "version": "0.0.0-placeholder",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "create-content-model",
-            "version": "1.0.0",
+            "version": "0.0.0-placeholder",
             "license": "ISC",
             "dependencies": {
                 "@wordpress/block-editor": "^14.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
     "name": "create-content-model",
-    "version": "1.0.0",
-    "main": ".prettierrc.js",
+    "version": "0.0.0-placeholder",
     "scripts": {
         "prepare": "husky",
         "dev-server": "npx @wp-now/wp-now start --wp=nightly --skip-browser --blueprint=dev.json",


### PR DESCRIPTION
Fixes https://github.com/Automattic/create-content-model/issues/73

## TODO

- [x] Double check it works
- [x] [Add instructions on how to add a release from GitHub](https://github.com/Automattic/create-content-model/commit/a77540f793ca1b95c6cf2a2a48ddf6d3f4eb35b7)
- [ ] Adapt the playground release workflow to run after the tag has been published