### PR TITLE
Fix release workflow sed command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: 20
           cache: "npm"
       - run: npm install
-      - run: "find . -type f -exec sed -i 's/0.0.0-placeholder/${{ github.ref_name }}/g' {} +"
+      - run: "find . -type f -exec sed -i 's/0.0.0-placeholder/${{ steps.get_tag.outputs.tag_name }}/g' {} +"
       - run: npm run plugin-zip
       - uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
`github.ref_name` is empty according to: https://github.com/orgs/community/discussions/64528
Use the `tag_name` from a previous step.