### PR TITLE
README: Put Playground and Download Release buttons side by side

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ _Define custom post types & fields in the Block Editor._
 
 WordPress.com’s experimental Create Content Model plugin transforms the way custom post types and custom fields are created and managed in WordPress by making use of the latest core features to bring content modeling into the Block Editor. Additionally, the created data model and data entry UI can be exported as a standalone, maintenance-free plugin.
 
-[![Try in WordPress Playground](https://img.shields.io/badge/Try%20in%20WordPress%20Playground-blue?style=for-the-badge)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/create-content-model/trunk/blueprint.json) [![Download Latest Release](https://img.shields.io/badge/Download%20Latest%20Release-blue?style=for-the-badge)](https://github.com/Automattic/create-content-model/releases/latest/download/create-content-model.zip)
+[![Try in WordPress Playground](https://img.shields.io/badge/Try%20in%20WordPress%20Playground-blue?style=for-the-badge)](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Automattic/create-content-model/trunk/blueprint.json)
 
 [[video]]
 
 ## Getting Started
 
 Find detailed instructions on creating your content model using this plugin in the [Get Started](/GETSTARTED.md) guide.
+
+[![Download Latest Release](https://img.shields.io/badge/Download%20Latest%20Release-blue?style=for-the-badge)](https://github.com/Automattic/create-content-model/releases/latest/download/create-content-model.zip)
 
 ## About
 


### PR DESCRIPTION
Instead of on top of each other. Thoughts @alexapeduzzi @bacoords?

I'm actually thinking of removing the "Download Release" button since it's already accessible from the sidebar 🤔 

![image](https://github.com/user-attachments/assets/fa15314e-6d99-4f62-b58d-c59f21eb1121)
