### PR TITLE
Use template instead of the default_content hook to modify the CM placeholder

### DIFF
--- a/includes/manager/class-content-model-loader.php
+++ b/includes/manager/class-content-model-loader.php
@@ -63,10 +63,9 @@ class Content_Model_Loader {
 		add_action( 'the_post', array( $this, 'map_template_to_content_model_editor_signature' ) );
 
 		/**
-		 * Update placeholder prompts to be more suitable for creating a new model.
+		 * Update title placeholder to be more suitable for creating a new model.
 		 */
 		add_filter( 'enter_title_here', array( $this, 'set_title_placeholder' ), 10, 2 );
-		add_filter( 'default_content', array( $this, 'set_content_placeholder' ), 10, 2 );
 	}
 
 	/**
@@ -111,6 +110,12 @@ class Content_Model_Loader {
 				'show_in_menu'       => true,
 				'show_in_rest'       => true,
 				'supports'           => array( 'title', 'editor', 'custom-fields' ),
+				'template'           => array(
+					array(
+						'core/paragraph',
+						array( 'placeholder' => __( 'Start building your model' ) ),
+					),
+				),
 			)
 		);
 
@@ -328,23 +333,5 @@ class Content_Model_Loader {
 			return __( 'Add model name' );
 		}
 		return $title;
-	}
-
-	/**
-	 * Sets the content placeholder for the Content Model post type.
-	 *
-	 * @param string  $content The default content.
-	 * @param WP_Post $post    The current post object.
-	 * @return string The modified default content.
-	 */
-	public function set_content_placeholder( $content, $post ) {
-		if ( Content_Model_Manager::POST_TYPE_NAME === $post->post_type ) {
-			$placeholder = __( 'Start building your model' );
-			return sprintf(
-				'<!-- wp:paragraph {"placeholder":"%s"} --><p></p><!-- /wp:paragraph -->',
-				esc_attr( $placeholder )
-			);
-		}
-		return $content;
 	}
 }


### PR DESCRIPTION
The `default_content` hook was creating an unwanted edit in the content model creation page, which was preventing the user from leaving even though nothing was changed.

@candy02058912 feel free to merge this PR.