### PR TITLE
Add notice when model name is empty on publish

### DIFF
--- a/includes/manager/src/hooks/use-content-model-name-length-restrictor.js
+++ b/includes/manager/src/hooks/use-content-model-name-length-restrictor.js
@@ -7,7 +7,7 @@ import { store as noticesStore } from '@wordpress/notices';
 export const useContentModelNameLengthRestrictor = () => {
 	const { editPost, lockPostSaving, unlockPostSaving } =
 		useDispatch( editorStore );
-	const { createNotice } = useDispatch( noticesStore );
+	const { createNotice, removeNotice } = useDispatch( noticesStore );
 
 	const { title, isPublishSidebarOpened, isPublishingPost } = useSelect(
 		( select ) => ( {
@@ -25,6 +25,8 @@ export const useContentModelNameLengthRestrictor = () => {
 			lockPostSaving( 'title-empty-lock' );
 		} else {
 			unlockPostSaving( 'title-empty-lock' );
+			removeNotice( 'title-empty-notice' );
+
 			editPost( { title: trimmedTitle.substring( 0, 20 ) } );
 
 			if ( trimmedTitle.length > 20 ) {
@@ -61,5 +63,6 @@ export const useContentModelNameLengthRestrictor = () => {
 		unlockPostSaving,
 		editPost,
 		createNotice,
+		removeNotice,
 	] );
 };


### PR DESCRIPTION
Adds a notice to inform the user that they cannot publish with an empty model name.

## Before

https://github.com/user-attachments/assets/ef0b32a8-bd53-4200-a871-319adc547187



## After

https://github.com/user-attachments/assets/af7e8436-c0d3-4417-b326-a210c68ff30b


