### PR TITLE
Replace placeholder version with commit for latest trunk releases

### DIFF
--- a/.github/workflows/publish-latest-plugin-zip.yml
+++ b/.github/workflows/publish-latest-plugin-zip.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Update version to latest trunk commit
+        run: "find . -type f -exec sed -i 's/0.0.0-placeholder/${{ github.sha }}/g' {} +"
+
       - name: Build and create plugin zip
         run: npm run plugin-zip
 


### PR DESCRIPTION
It uses the commit sha as the version for building the plugin zip file for the latest trunk releases to https://github.com/Automattic/create-content-model-releases/tree/latest.