### PR TITLE
Use tag-dev-sha as version name for latest trunk plugin build

### DIFF
--- a/.github/workflows/publish-latest-plugin-zip.yml
+++ b/.github/workflows/publish-latest-plugin-zip.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.get_tag.outputs.tag_name }}
 
     steps:
       - name: Checkout code
@@ -18,11 +20,15 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Get tag name
+        id: get_tag
+        run: echo "tag_name=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
       - name: Install dependencies
         run: npm ci
 
       - name: Update version to latest trunk commit
-        run: "find . -type f -exec sed -i 's/0.0.0-placeholder/${{ github.sha }}/g' {} +"
+        run: "find . -type f -exec sed -i 's/0.0.2-dev-e35b494710b4d5d40cc0b7adfe5398ef52307bfb/${{ steps.get_tag.outputs.tag_name }}-${{ github.sha }}/g' {} +"
 
       - name: Build and create plugin zip
         run: npm run plugin-zip


### PR DESCRIPTION
Related to #129 

Using sha only as a version will result in invalid version, so we're using tag-dev-sha as the version name for the latest trunk plugin release in https://github.com/Automattic/create-content-model-releases/tree/latest.
For example: `0.0.2-dev-e35b494710b4d5d40cc0b7adfe5398ef52307bfb`