### PR TITLE
Replace placeholder version with tag-dev-sha for latest trunk releases

### DIFF
--- a/.github/workflows/publish-latest-plugin-zip.yml
+++ b/.github/workflows/publish-latest-plugin-zip.yml
@@ -1,8 +1,7 @@
 name: Publish plugin to Automattic/create-content-model-releases latest on trunk merge
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  push:
     branches:
       - trunk
 
@@ -63,4 +62,4 @@ jobs:
           destination-repository-name: "create-content-model-releases"
           user-name: ${{ github.actor }}
           user-email: ${{ steps.get_email.outputs.email }}
-          target-branch: test
+          target-branch: latest


### PR DESCRIPTION
We will use latest_tag-dev-commit_sha as the version for building the plugin zip file for the `latest` trunk releases to https://github.com/Automattic/create-content-model-releases/tree/latest.

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/user-attachments/assets/ee26c1dc-0f14-4b5b-a2c3-4ba4556399bf">  | <img src="https://github.com/user-attachments/assets/dbd4b14b-8ab7-42be-818a-fbe5649c0d59">|
