### PR TITLE
Update blueprint to use latest tagged release version

### DIFF
--- a/blueprint.json
+++ b/blueprint.json
@@ -15,7 +15,7 @@
 			"step": "installPlugin",
 			"pluginZipFile": {
 				"resource": "url",
-				"url": "https://raw.githubusercontent.com/Automattic/create-content-model-releases/latest/create-content-model.zip"
+				"url": "https://raw.githubusercontent.com/Automattic/create-content-model-releases/releases/create-content-model.zip"
 			}
 		},
 		{


### PR DESCRIPTION
We were using the latest trunk release version before, but we are now changing to the latest tagged release version for stability.