### PR TITLE
Enhance accuracy of guessing the default plural label

### DIFF
--- a/includes/manager/src/components/cpt-settings-panel.js
+++ b/includes/manager/src/components/cpt-settings-panel.js
@@ -9,6 +9,16 @@ import {
 import { useEntityProp } from '@wordpress/core-data';
 import { POST_TYPE_NAME } from '../constants';
 
+function getPlural( singular ) {
+	if ( singular.endsWith( 'y' ) ) {
+		return `${ singular.slice( 0, -1 ) }ies`;
+	}
+	if ( singular.endsWith( 's' ) || singular.endsWith( 'ch' ) ) {
+		return `${ singular }es`;
+	}
+	return `${ singular }s`;
+}
+
 export const CPTSettingsPanel = function () {
 	const [ meta, setMeta ] = useEntityProp(
 		'postType',
@@ -27,7 +37,7 @@ export const CPTSettingsPanel = function () {
 	useLayoutEffect( () => {
 		if ( title !== lastTitle.current ) {
 			lastTitle.current = title;
-			setMeta( { ...meta, plural_label: `${ title }s` } );
+			setMeta( { ...meta, plural_label: getPlural( title ) } );
 		}
 	}, [ title, meta, setMeta ] );
 

--- a/includes/runtime/class-content-model.php
+++ b/includes/runtime/class-content-model.php
@@ -111,7 +111,7 @@ final class Content_Model {
 	 * @return string The plural label.
 	 */
 	public function get_plural_label() {
-		return $this->get_model_meta( 'plural_label' ) ?? "{$this->title}s";
+		return $this->get_model_meta( 'plural_label' ) ?? $this->get_plural( $this->title );
 	}
 
 	/**
@@ -141,6 +141,22 @@ final class Content_Model {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Attempts to get the plural label based on the given singular label.
+	 *
+	 * @param string $singular The singular label.
+	 * @return string The plural label (best guess based on common English grammar rules).
+	 */
+	private function get_plural( $singular ) {
+		if ( str_ends_with( $singular, 'y' ) ) {
+			return substr( $singular, 0, -1 ) . 'ies';
+		}
+		if ( str_ends_with( $singular, 's' ) || str_ends_with( $singular, 'ch' ) ) {
+			return "{$singular}es";
+		}
+		return "{$singular}s";
 	}
 
 	/**


### PR DESCRIPTION
This is just a tiny enhancement that improves the accuracy of _guessing_ what's the plural label of the provided singular label is.

The PR implements this on both the server-side and client-side.